### PR TITLE
fix landing page layout: dropped menu on FF40

### DIFF
--- a/public/css/layouts/marketing.css
+++ b/public/css/layouts/marketing.css
@@ -94,6 +94,7 @@ a.pure-button-primary {
     padding: 0.5em;
     text-align: center;
     box-shadow: 0 1px 1px rgba(0,0,0, 0.10);
+    white-space: normal;
 }
 .home-menu {
     background: #2d3e50;


### PR DESCRIPTION
Fix landing page layout: dropped menu on FF40.

![dropped menu on FF40](https://i.gyazo.com/3f47940f8d94e5dfa57f40ac45b02a5c.png)
![fixed](https://i.gyazo.com/4ae2c868921d0409a4f060cda3d5cea9.png)

https://bugzilla.mozilla.org/show_bug.cgi?id=488725

use white-space: normal to make float div not dropped to another line. 
